### PR TITLE
fix: Added cache-control immutable header

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -5,7 +5,7 @@
 
 ## Disable cache re-validation for images  and set max age to 3 days
 /*
-  Cache-Control: public, max-age=259200
+  Cache-Control: public, max-age=259200, immutable
 
 /*
   Access-Control-Allow-Origin: *


### PR DESCRIPTION
While it works fine without this header in Chrome, this is needed for Firefox to cache without re-validation.